### PR TITLE
removes salt from serialize

### DIFF
--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -303,7 +303,7 @@ KeyStore.isSeedValid = function(seed) {
 };
 
 // Takes keystore serialized as string and returns an instance of KeyStore
-KeyStore.deserialize = function (keystore) {
+KeyStore.deserialize = function (keystore,salt) {
   var jsonKS = JSON.parse(keystore);
 
   if (jsonKS.version === undefined || jsonKS.version !== 3) {
@@ -313,8 +313,8 @@ KeyStore.deserialize = function (keystore) {
   // Create keystore
   var keystoreX = new KeyStore();
 
-  keystoreX.salt = jsonKS.salt
-  keystoreX.hdPathString = jsonKS.hdPathString
+  keystoreX.salt = salt;
+  keystoreX.hdPathString = jsonKS.hdPathString;
   keystoreX.encSeed = jsonKS.encSeed;
   keystoreX.encHdRootPriv = jsonKS.encHdRootPriv;
   keystoreX.version = jsonKS.version;
@@ -363,7 +363,6 @@ KeyStore.prototype.serialize = function () {
                 'addresses' : this.addresses,
                 'encPrivKeys' : this.encPrivKeys,
                 'hdPathString' : this.hdPathString,
-                'salt': this.salt,
                 'hdIndex' : this.hdIndex,
                 'version' : this.version};
 


### PR DESCRIPTION
Currently, the salt is stored unencrypted in the serialized vault, this makes it only rely on the password. 
For our use case, this fits our idea of working where salt is provided manually in order to unlock the vault.