### PR TITLE
Moe/phrase generation

### DIFF
--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -71,7 +71,7 @@ KeyStore.prototype.init = function(mnemonic, pwDerivedKey, hdPathString, salt) {
 
   if ( (typeof pwDerivedKey !== 'undefined') && (typeof mnemonic !== 'undefined') ){
     var words = mnemonic.split(' ');
-    if (!Mnemonic.isValid(mnemonic, Mnemonic.Words.ENGLISH) || words.length !== 12){
+    if (!Mnemonic.isValid(mnemonic, Mnemonic.Words.ENGLISH)){
       throw new Error('KeyStore: Invalid mnemonic');
     }
 

--- a/lib/keystore.js
+++ b/lib/keystore.js
@@ -279,11 +279,12 @@ KeyStore._concatAndSha256 = function(entropyBuf0, entropyBuf1) {
 // If extraEntropy is not set, the random number generator
 // is used directly.
 
-KeyStore.generateRandomSeed = function(extraEntropy) {
-
+KeyStore.generateRandomSeed = function(extraEntropy,entropyStrength) {
+ 
   var seed = '';
+  var entropy = entropyStrength ? entropyStrength : 128;
   if (extraEntropy === undefined) {
-    seed = new Mnemonic(Mnemonic.Words.ENGLISH);
+    seed = new Mnemonic(entropy,Mnemonic.Words.ENGLISH);
   }
   else if (typeof extraEntropy === 'string') {
     var entBuf = new Buffer(extraEntropy);


### PR DESCRIPTION
This PR removes the 12-word restriction during seed recovery and new wallet generation. 
This addition is still backward compatible as it still generates a 128bit key by default. 